### PR TITLE
improvements with no listing campaigns but get each campaign [because…

### DIFF
--- a/app/apiEndpoints/apiEndpoints.ts
+++ b/app/apiEndpoints/apiEndpoints.ts
@@ -100,9 +100,9 @@ const getMemberRewards = async (
     )
 }
 
-const getCampaign = async (campaignName: string) => {
+const getCampaign = async (campaignId: string) => {
     return await fetch(
-        `/api/voucherify/get-campaign?campaignId=${campaignName}`,
+        `/api/voucherify/get-campaign?campaignId=${campaignId}`,
         {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' },

--- a/app/hooks/useLoyalty.ts
+++ b/app/hooks/useLoyalty.ts
@@ -58,7 +58,7 @@ export const useLoyalty = ({
                 await validateLoyaltyCampaigns(customerSourceId)
 
             setLoyaltyPoints(
-                loyaltyCampaigns.find((campaign) =>
+                loyaltyCampaigns?.find((campaign) =>
                     [
                         CAMPAIGNS.LOYALTY_PROGRAM_EARN_AND_BURN_ID,
                         CAMPAIGNS.LOYALTY_PROGRAM_ID,
@@ -67,7 +67,7 @@ export const useLoyalty = ({
             )
 
             setRewardPoints(
-                loyaltyCampaigns.find(
+                loyaltyCampaigns?.find(
                     (campaign) =>
                         campaign?.id === CAMPAIGNS.MILESTONE_REWARDS_PROGRAM_ID
                 )?.loyaltyPoints || 0
@@ -114,11 +114,11 @@ export const useLoyalty = ({
 
     const validateLoyaltyCampaigns = async (
         customerSourceId: string | null | undefined
-    ): Promise<BasicLoyaltyCampaignsInfo[]> => {
+    ): Promise<BasicLoyaltyCampaignsInfo[] | void> => {
         const res = await getCampaign(CAMPAIGNS.LOYALTY_PROGRAM_ID)
 
         if (res.status === 404) {
-            setLoyaltyError(
+            return setLoyaltyError(
                 `Could not get Loyalty Program - check if campaign is not deleted in Voucherify dashboard.`
             )
         }
@@ -128,7 +128,7 @@ export const useLoyalty = ({
         )
 
         if (res2.status === 404) {
-            setLoyaltyError(
+            return setLoyaltyError(
                 `Could not get Loyalty Program - earn and burn - check if campaign is not deleted in Voucherify dashboard.`
             )
         }
@@ -142,17 +142,16 @@ export const useLoyalty = ({
         )
 
         if (isActiveMultipleLoyaltyCampaigns) {
-            setLoyaltyError(
+            return setLoyaltyError(
                 `You have activated two loyalty programs (Loyalty Program, Loyalty Program - earn and burn). Disable one of them for the app to work properly.`
             )
         }
-
         const inactiveLoyaltyCampaigns = campaigns.every(
             (campaign) => !campaign.active
         )
 
         if (inactiveLoyaltyCampaigns) {
-            setLoyaltyError(
+            return setLoyaltyError(
                 `For some reason, none of the loyalty campaigns are active for the user.`
             )
         }

--- a/app/hooks/useLoyalty.ts
+++ b/app/hooks/useLoyalty.ts
@@ -1,5 +1,9 @@
 import { CampaignResponse, VouchersResponse } from '@voucherify/sdk'
-import { listCampaigns, listVouchers } from '../apiEndpoints/apiEndpoints'
+import {
+    getCampaign,
+    listCampaigns,
+    listVouchers,
+} from '../apiEndpoints/apiEndpoints'
 import { CAMPAIGNS } from '@/enum/campaigns'
 import { useEffect, useState } from 'react'
 import { WebhookResponse } from '@/types/webhook-response'
@@ -111,18 +115,15 @@ export const useLoyalty = ({
     const validateLoyaltyCampaigns = async (
         customerSourceId: string | null | undefined
     ): Promise<BasicLoyaltyCampaignsInfo[]> => {
-        const res = await listCampaigns()
-        const { campaigns }: { campaigns: CampaignResponse[] } =
-            await res.json()
-
-        const validCampaigns = campaigns.filter((campaign) =>
-            [
-                CAMPAIGNS.LOYALTY_PROGRAM_EARN_AND_BURN_ID,
-                CAMPAIGNS.LOYALTY_PROGRAM_ID,
-            ].includes(campaign.id as CAMPAIGNS)
+        const res = await getCampaign(CAMPAIGNS.LOYALTY_PROGRAM_ID)
+        const res2 = await getCampaign(
+            CAMPAIGNS.LOYALTY_PROGRAM_EARN_AND_BURN_ID
         )
+        const { campaign: loyaltyProgram } = await res.json()
+        const { campaign: earnAndBurnProgram } = await res2.json()
+        const campaigns = [loyaltyProgram, earnAndBurnProgram]
 
-        const isActiveMultipleLoyaltyCampaigns = validCampaigns.every(
+        const isActiveMultipleLoyaltyCampaigns = campaigns.every(
             (campaign) => campaign.active
         )
 
@@ -132,7 +133,7 @@ export const useLoyalty = ({
             )
         }
 
-        const inactiveLoyaltyCampaigns = validCampaigns.every(
+        const inactiveLoyaltyCampaigns = campaigns.every(
             (campaign) => !campaign.active
         )
 

--- a/app/hooks/useLoyalty.ts
+++ b/app/hooks/useLoyalty.ts
@@ -116,11 +116,25 @@ export const useLoyalty = ({
         customerSourceId: string | null | undefined
     ): Promise<BasicLoyaltyCampaignsInfo[]> => {
         const res = await getCampaign(CAMPAIGNS.LOYALTY_PROGRAM_ID)
+
+        if (res.status === 404) {
+            setLoyaltyError(
+                `Could not get Loyalty Program - check if campaign is not deleted in Voucherify dashboard.`
+            )
+        }
+
         const res2 = await getCampaign(
             CAMPAIGNS.LOYALTY_PROGRAM_EARN_AND_BURN_ID
         )
+
+        if (res2.status === 404) {
+            setLoyaltyError(
+                `Could not get Loyalty Program - earn and burn - check if campaign is not deleted in Voucherify dashboard.`
+            )
+        }
         const { campaign: loyaltyProgram } = await res.json()
         const { campaign: earnAndBurnProgram } = await res2.json()
+
         const campaigns = [loyaltyProgram, earnAndBurnProgram]
 
         const isActiveMultipleLoyaltyCampaigns = campaigns.every(


### PR DESCRIPTION
Improvements of getting each campaign instead of listing all campaigns.

**Why?**

When there more campaigns than 10, pagination is enabled and it is possible not to achieve the result with desired campaign. Better is to use `get campaign` endpoint to get information about one campaign. Pagination won't affect on this case.